### PR TITLE
Changed outs to new transitive depset instead of old union operator

### DIFF
--- a/tools/springboot/springboot.bzl
+++ b/tools/springboot/springboot.bzl
@@ -84,11 +84,12 @@ ${cmd}
 #  do not use directly, see the SpringBoot Macro below
 
 def _springboot_rule_impl(ctx):
-  outs = depset()
-  outs += ctx.attr.app_compile_rule.files
-  outs += ctx.attr.genmanifest_rule.files
-  outs += ctx.attr.gengitinfo_rule.files
-  outs += ctx.attr.genjar_rule.files
+  outs = depset(transitive = [
+    ctx.attr.app_compile_rule.files,
+    ctx.attr.genmanifest_rule.files,
+    ctx.attr.gengitinfo_rule.files,
+    ctx.attr.genjar_rule.files
+  ])
 
   # setup the script that runs "java -jar <springboot.jar>" when calling
   # "bazel run" with the springboot target


### PR DESCRIPTION
With the latest bazel version 2.0.0 the spring_boot rule can no longer be executed because of the following error message:
```
ERROR: /opt/tgs_workspace_bazel/apex.gaming.server.tablegame-boot/BUILD:84:1: in _springboot_rule rule //apex.gaming.server.tablegame-boot:apex-gaming-server-tablegame-boot: 
Traceback (most recent call last):
	File "/opt/tgs_workspace_bazel/apex.gaming.server.tablegame-boot/BUILD", line 84
		_springboot_rule(name = 'apex-gaming-server-tablegame-boot')
	File "/opt/tgs_workspace_bazel/tools/springboot/springboot.bzl", line 88, in _springboot_rule_impl
		outs += ctx.attr.app_compile_rule.files
`+` operator on a depset is forbidden. See https://docs.bazel.build/versions/master/skylark/depsets.html for recommendations. Use --incompatible_depset_union=false to temporarily disable this check.
ERROR: Analysis of target '//apex.gaming.server.tablegame-boot:apex-gaming-server-tablegame-boot' failed; build aborted: Analysis of target '//apex.gaming.server.tablegame-boot:apex-gaming-server-tablegame-boot' failed; build aborted
```

This pull request fixes this behaviour by using the new transitive operation when creating a depset