### PR TITLE
fixes for maven_install

### DIFF
--- a/tools/springboot/springboot_pkg.sh
+++ b/tools/springboot/springboot_pkg.sh
@@ -167,7 +167,7 @@ while [ "$i" -le "$#" ]; do
   libname=$(basename $lib)
   libdir=$(dirname $lib)
 
-  if [[ $libname == spring-boot-loader* ]]; then
+  if [[ $libname == *spring-boot-loader* ]]; then
     # if libname is prefixed with the string 'spring-boot-loader' then...
     # the Spring Boot Loader classes are special, they must be extracted at the root level /,
     #   not in BOOT-INF/lib/loader.jar nor BOOT-INF/classes/**/*.class

--- a/tools/springboot/write_manifest.sh
+++ b/tools/springboot/write_manifest.sh
@@ -12,7 +12,7 @@ FOUND_SPRING_JAR=0
 # Looking for the springboot jar injected by springboot.bzl and extracting the version
 for var in "$@"
 do
-  if [[ $var = *"org_springframework_boot_spring_boot/jar/spring-boot-"* ]]; then
+  if [[ $var = *"spring-boot-"* ]]; then
     SPRING_VERSION=$(echo "$var" | rev | cut -c5- | rev | cut -d / -f 4 | cut -d - -f 3)
     FOUND_SPRING_JAR=1
     break


### PR DESCRIPTION
The internal repo we have did not transition to maven_install as we expected due to some issue. But I was finally able to build a test workspace and test the changes suggested by @thundergolfer and @dan-cohn in issue #13 

The fixes are backwards compatible with maven_jar, and thus can be merged to master. I have some additional work (import_bundles, docs) to fully support maven_install, but the core rule logic is fixed.