### PR TITLE
singlejar implementation

### DIFF
--- a/tools/springboot/springboot.bzl
+++ b/tools/springboot/springboot.bzl
@@ -177,6 +177,7 @@ def springboot(name, java_library, boot_app_class, deps, fail_on_duplicate_class
     # The resolved input_file_paths array is made available as the $(SRCS) token in the cmd string.
     # Skylark will convert the logical input_file_paths into real file system paths when surfaced in $(SRCS)
     #  cmd format (see springboot_pkg.sh)
+    #    param0: location of the jar utility (singlejar)
     #    param1: boot application classname (the @SpringBootApplication class)
     #    param2: verify_duplicates
     #    param3: jdk path for running java tools e.g. jar; $(JAVABASE)
@@ -188,8 +189,15 @@ def springboot(name, java_library, boot_app_class, deps, fail_on_duplicate_class
     native.genrule(
         name = genjar_rule,
         srcs = [java_library, ":" + genmanifest_rule, ":" + gengitinfo_rule, ":" + dep_aggregator_rule],
-        cmd = "$(location @bazel_springboot_rule//tools/springboot:springboot_pkg.sh) " + boot_app_class + " " + verify_str + " $(JAVABASE) " + name + " $@ $(SRCS)",
-        tools = ["@bazel_springboot_rule//tools/springboot:springboot_pkg.sh", "@bazel_springboot_rule//tools/springboot:verify_conflict.py", "@bazel_springboot_rule//tools/springboot:whitelist.txt"],
+        cmd = "$(location @bazel_springboot_rule//tools/springboot:springboot_pkg.sh) " +
+              "$(location @bazel_tools//tools/jdk:singlejar) " +
+              boot_app_class + " " + verify_str + " $(JAVABASE) " + name + " $@ $(SRCS)",
+        tools = [
+            "@bazel_springboot_rule//tools/springboot:springboot_pkg.sh",
+            "@bazel_springboot_rule//tools/springboot:verify_conflict.py",
+            "@bazel_springboot_rule//tools/springboot:whitelist.txt",
+            "@bazel_tools//tools/jdk:singlejar",
+        ],
         tags = tags,
         outs = [_get_springboot_jar_file_name(name)],
         toolchains = ["@bazel_tools//tools/jdk:current_host_java_runtime"],  # so that JAVABASE is computed

--- a/tools/springboot/springboot_pkg.sh
+++ b/tools/springboot/springboot_pkg.sh
@@ -16,13 +16,14 @@
 # /tmp/bazel/debug/springboot for each Spring Boot app.
 
 RULEDIR=$(pwd)
-MAINCLASS=$1
-VERIFY_DUPE=$2
-JAVABASE=$3
-APPJAR_NAME=$4
-OUTPUTJAR=$5
-APPJAR=$6
-MANIFEST=$7
+SINGLEJAR_CMD=$(pwd)/$1
+MAINCLASS=$2
+VERIFY_DUPE=$3
+JAVABASE=$4
+APPJAR_NAME=$5
+OUTPUTJAR=$6
+APPJAR=$7
+MANIFEST=$8
 #GITPROPSFILE=$6
 
 #The coverage variable is used to make sure that the correct files are picked in case bazel coverage is run with this springboot rule
@@ -33,11 +34,11 @@ COVERAGE=1
 # This is a workaround to ensure that the MANIFEST is picked correctly.
 
 if [[ $MANIFEST = *"MANIFEST.MF" ]]; then
-    GITPROPSFILE=$8
+    GITPROPSFILE=$9
     COVERAGE=0
 else
-    MANIFEST=$7
-    GITPROPSFILE=$9
+    MANIFEST=$8
+    GITPROPSFILE=$10
 fi
 
 # package name (not guaranteed to be globally unique)
@@ -83,6 +84,7 @@ echo "**************************************************************************
 echo "Build time: $BUILD_DATE_TIME"  >> $DEBUGFILE
 echo "SPRING BOOT PACKAGER FOR BAZEL" >> $DEBUGFILE
 echo "  RULEDIR         $RULEDIR     (build working directory)" >> $DEBUGFILE
+echo "  SINGLEJAR       $SINGLEJAR_CMD (path to the singlejar utility)" >> $DEBUGFILE
 echo "  MAINCLASS       $MAINCLASS   (classname of the @SpringBootApplication class for the MANIFEST.MF file entry)" >> $DEBUGFILE
 echo "  OUTPUTJAR       $OUTPUTJAR   (the executable JAR that will be built from this rule)" >> $DEBUGFILE
 echo "  JAVABASE        $JAVABASE    (the path to the JDK2)" >> $DEBUGFILE
@@ -100,9 +102,9 @@ echo "Jar command:" >> $DEBUGFILE
 echo $JAR_COMMAND >> $DEBUGFILE
 
 if [[ $COVERAGE -eq 0 ]]; then
-    i=8
-else
     i=9
+else
+    i=10
 fi
 
 # log the list of dep jars we were given
@@ -135,7 +137,7 @@ if [[ $VERIFY_DUPE == "verify" ]]; then
 fi
 
 if [ -z "${DEBUG_SPRINGBOOT_RULE}" ]; then
-  # cleanup, unless in debug mode: this file is only needed for the conflicting 
+  # cleanup, unless in debug mode: this file is only needed for the conflicting
   # classes check above
   rm -f $CLASSLIST_FILENAME
 fi
@@ -160,16 +162,16 @@ $JAR_COMMAND -xf $RULEDIR/$APPJAR
 cd $WORKING_DIR
 
 if [[ $COVERAGE -eq 0 ]]; then
-    i=9
-else
     i=10
+else
+    i=11
 fi
 
 while [ "$i" -le "$#" ]; do
   eval "lib=\${$i}"
   libname=$(basename $lib)
   libdir=$(dirname $lib)
-
+  echo "DEBUG: libname: $libname" >> $DEBUGFILE
   if [[ $libname == *spring-boot-loader* ]]; then
     # if libname is prefixed with the string 'spring-boot-loader' then...
     # the Spring Boot Loader classes are special, they must be extracted at the root level /,
@@ -196,9 +198,6 @@ cat $RULEDIR/$GITPROPSFILE >> $DEBUGFILE
 cp -f $RULEDIR/$GITPROPSFILE $WORKING_DIR/BOOT-INF/classes
 
 # Create the output jar
-# Note that a critical part of this step is to pass option 0 into the jar command
-# that tells jar not to compress the jar, only package it. Spring Boot does not
-# allow the jar file to be compressed (it will fail at startup).
 cd $WORKING_DIR
 
 # write debug telemetry data
@@ -208,9 +207,24 @@ find . >> $DEBUGFILE
 ELAPSED_PRE_JAR=$(( $SECONDS - BUILD_TIME_START ))
 echo "DEBUG: elapsed time (seconds): $ELAPSED_PRE_JAR" >> $DEBUGFILE
 
-# run the command
-echo "DEBUG: Run jar command:" >> $DEBUGFILE
-$JAR_COMMAND -cfm0 $RULEDIR/$OUTPUTJAR $RULEDIR/$MANIFEST .  2>&1 | tee -a $DEBUGFILE
+# first use jar to create a correct jar file for Spring Boot
+# Note that a critical part of this step is to pass option 0 into the jar command
+# that tells jar not to compress the jar, only package it. Spring Boot does not
+# allow the jar file to be compressed (it will fail at startup).
+RAW_OUTPUT=$RULEDIR/${OUTPUTJAR}.raw
+echo "DEBUG: Running jar command to produce $RAW_OUTPUT" >> $DEBUGFILE
+$JAR_COMMAND -cfm0 $RAW_OUTPUT $RULEDIR/$MANIFEST .  2>&1 | tee -a $DEBUGFILE
+
+# now use Bazel's singlejar to re-jar it which normalizes timestamps as Jan 1 2010
+# note that it does not use the MANIFEST from the jar file, which is a bummer
+# so we have to respecify the manifest data
+# TODO we could rewrite the write_manfiest.sh to produce inputs compatible for singlejar
+SINGLEJAR_OPTIONS="--normalize --dont_change_compression" # add in --verbose for more details from command
+SINGLEJAR_MAINCLASS="--main_class org.springframework.boot.loader.JarLauncher"
+$SINGLEJAR_CMD $SINGLEJAR_OPTIONS $SINGLEJAR_MAINCLASS \
+    --deploy_manifest_lines "Start-Class: $MAINCLASS" \
+    --sources $RAW_OUTPUT \
+    --output $RULEDIR/$OUTPUTJAR 2>&1 | tee -a $DEBUGFILE
 
 if [ $? -ne 0 ]; then
   echo "ERROR: Failed creating the JAR file $WORKING_DIR." | tee -a $DEBUGFILE

--- a/tools/springboot/write_manifest.sh
+++ b/tools/springboot/write_manifest.sh
@@ -35,7 +35,6 @@ JAVA_VERSION=$(echo "$JAVA_STRING" | head -n1 | cut -d ' ' -f 3 | rev | cut -c2-
 echo "Manifest-Version: 1.0" > $MANIFESTFILE
 echo "Created-By: Bazel" >> $MANIFESTFILE
 echo "Built-By: Bazel" >> $MANIFESTFILE
-echo "Throw-Down: hootenanny" >> $MANIFESTFILE
 echo "Main-Class: org.springframework.boot.loader.JarLauncher" >> $MANIFESTFILE
 echo "Spring-Boot-Classes: BOOT-INF/classes/" >> $MANIFESTFILE
 echo "Spring-Boot-Lib: BOOT-INF/lib/" >> $MANIFESTFILE


### PR DESCRIPTION
This is a big change. This PR causes the rule to use Bazel's singlejar to package the final spring boot jar, instead of the jar command. This solves issue #19 which wants to have a hermetic output. 

We have been running with this new packaging approach internally at Salesforce for 4 days and haven't seen any issues in CI or in actual deployments. If this breaks you after we merge to master, please post back asap. I decided NOT to make this feature opt-in, it is enabled for all.