### PR TITLE
use captive python instead of system python, and other improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ setGitOSSUser.sh
 
 # python
 __pycache__
+
+# //tools/python_interpreter
+captive_python3
+bin

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,3 +23,14 @@ external_maven_jars()
 
 load("@maven//:defs.bzl", "pinned_maven_install")
 pinned_maven_install()
+
+
+#
+# CAPTIVE PYTHON
+#
+# Install a specific version of python to be used by the Bazel build with the invocation below.
+# Before this will work, you need to follow the instructions in //tools/python_interpreter.
+
+#register_toolchains(
+#    "//tools/python_interpreter:captive_python_toolchain",
+#)

--- a/samples/helloworld/BUILD
+++ b/samples/helloworld/BUILD
@@ -14,6 +14,8 @@ lib_deps = [
   "//samples/helloworld/libs/lib2",
 ]
 
+# service specific list of jars that we dont want to trigger errors for the
+# dupe class checker (these jars have known dupe classes)
 filegroup(
     name = "dupe_class_allowlist",
     srcs = glob([
@@ -45,7 +47,7 @@ springboot(
 
     # TO TEST THE DUPE CLASSES FEATURE:
     #   There is an intentionally duplicated class in lib1 and lib2. Do this:
-    #   1. change this to fail_on_duplicate_classes = True
+    #   1. set fail_on_duplicate_classes = True
     #   2. comment out lib1 or lib2 in helloworld_dupeclass_allowlist.txt
     #   Build should fail due to the duplicate class.
     fail_on_duplicate_classes = True,

--- a/samples/helloworld/helloworld_dupeclass_allowlist.txt
+++ b/samples/helloworld/helloworld_dupeclass_allowlist.txt
@@ -1,6 +1,6 @@
 jakarta.annotation-api-1.3.5.jar
-spring-jcl-5.2.1.RELEASE.jar
-liblib2.jar
-commons-logging-1.2.jar
 javax.annotation-api-1.3.2.jar
+spring-jcl-5.2.1.RELEASE.jar
+commons-logging-1.2.jar
 liblib1.jar
+liblib2.jar

--- a/tools/python_interpreter/BUILD
+++ b/tools/python_interpreter/BUILD
@@ -1,0 +1,43 @@
+load("@bazel_tools//tools/python:toolchain.bzl", "py_runtime_pair")
+
+#
+# What Python is being used?
+#
+# Simple utility to print out the python executable being used by Bazel.
+#   bazel run //tools/python_interpreter:check_python_path
+
+py_binary(
+    name = "check_python_path",
+    srcs = [
+        "check_python_path.py",
+    ],
+)
+
+
+#
+# CAPTIVE PYTHON
+#
+# Install a specific version of python to be used by the Bazel build with the
+# rule invocations below. This is disabled by default. To enable, follow these steps:
+# 1. Create a subdirectory 'captive_python3' and install python3 into it. You should
+#    end up with ./captive_python3/bin/python3 existing on the filesystem.
+# 2. Uncomment the rule invocations below.
+# 3. Uncomment the python toolchain invocation in the WORKSPACE file.
+
+#py_runtime(
+#    name = "python3",
+#    interpreter = "captive_python3/bin/python3",
+#    python_version = "PY3",
+#    visibility = ["//visibility:public"],
+#)
+
+#py_runtime_pair(
+#    name = "captive_python_runtimes",
+#    py3_runtime = ":python3",
+#)
+
+#toolchain(
+#    name = "captive_python_toolchain",
+#    toolchain = ":captive_python_runtimes",
+#    toolchain_type = "@bazel_tools//tools/python:toolchain_type",
+#)

--- a/tools/python_interpreter/README.md
+++ b/tools/python_interpreter/README.md
@@ -1,0 +1,36 @@
+## Captive Python
+
+This package sets up the captive python environment for Bazel builds for this workspace.
+To ensure hermetic results, we don't rely on the system python for builds.
+
+### Setup
+
+Within Salesforce, we have a setup script that developers/CI systems run after cloning the repository,
+  but before running a Bazel build.
+That script installs Python3 into a *captive_python3* subdirectory of this package.
+Then, *BUILD* and *WORKSPACE* rules install the captive python3 binary as the python toolchain.
+
+
+### Python Toolchain Registration
+
+The [BUILD](BUILD) file defines the python toolchain.
+You will need to uncomment the rules in the BUILD file once you have performed the setup step.
+
+But this by itself does not have an affect.
+The key step is this invocation in the [WORKSPACE](../../WORKSPACE) file.
+
+```
+register_toolchains(
+    "//tools/python_interpreter:sfdc_python_toolchain",
+)
+```
+
+This installs the captive version as the preferred python toolchain.
+
+### Verify the Captive Python
+
+To check that the captive python is being used by Bazel, run this:
+
+```
+bazel run //tools/python_interpreter:check_python_path
+```

--- a/tools/python_interpreter/check_python_path.py
+++ b/tools/python_interpreter/check_python_path.py
@@ -1,0 +1,3 @@
+import sys
+
+print(sys.executable)

--- a/tools/springboot/BUILD
+++ b/tools/springboot/BUILD
@@ -24,6 +24,7 @@ py_binary(
     srcs = [
         "check_dupe_classes.py",
     ],
+    visibility = ["//visibility:public"],
 )
 
 py_test(

--- a/tools/springboot/README.md
+++ b/tools/springboot/README.md
@@ -207,6 +207,10 @@ springboot(
 )
 ```
 
+The dupe class checking feature requires Python3.
+If you don't have Python3 available for your build, *fail_on_duplicate_classes* must be False.
+See [the Captive Python documentation](../python_interpreter) for more information on how to configure Python3.
+
 ### Debugging the Rule Execution
 
 If the environment variable `DEBUG_SPRINGBOOT_RULE` is set, the rule writes debug output to `$TMPDIR/bazel/debug/springboot`. If `$TMPDIR` is not defined, it defaults to `/tmp`.

--- a/tools/springboot/tests/check_dupe_classes_test.py
+++ b/tools/springboot/tests/check_dupe_classes_test.py
@@ -32,7 +32,7 @@ class TestVerifyDupeClasses(unittest.TestCase):
 
         springbootjar = self._create_springboot_jar("sb2.jar", jar_dir)
 
-        check_dupe_classes.run(springbootjar, ALLOWLIST_PATH)
+        check_dupe_classes.run(springbootjar, ALLOWLIST_PATH, None)
 
     def test_two_jars_with_duplicate_class__same_content(self):
         classes_dir1 = self._create_fake_class("MyClass.class", "classes1",
@@ -50,7 +50,7 @@ class TestVerifyDupeClasses(unittest.TestCase):
 
         springbootjar = self._create_springboot_jar("sb3.jar", jar_dir)
 
-        check_dupe_classes.run(springbootjar, ALLOWLIST_PATH)
+        check_dupe_classes.run(springbootjar, ALLOWLIST_PATH, None)
 
     def test_two_jars_with_duplicate_class__different_content(self):
         classes_dir1 = self._create_fake_class("MyClass.class", "classes1",
@@ -66,7 +66,7 @@ class TestVerifyDupeClasses(unittest.TestCase):
         springbootjar = self._create_springboot_jar("sb4.jar", jar_dir)
 
         with self.assertRaises(Exception) as ctx:
-            check_dupe_classes.run(springbootjar, ALLOWLIST_PATH)
+            check_dupe_classes.run(springbootjar, ALLOWLIST_PATH, None)
 
         self.assertIn("Found duplicate classes", str(ctx.exception))
 
@@ -83,7 +83,7 @@ class TestVerifyDupeClasses(unittest.TestCase):
 
         springbootjar = self._create_springboot_jar("sb5.jar", jar_dir)
 
-        check_dupe_classes.run(springbootjar, ALLOWLIST_PATH)
+        check_dupe_classes.run(springbootjar, ALLOWLIST_PATH, None)
 
 
     # HELPERS


### PR DESCRIPTION
Mainly, this PR improves the Spring Boot rule in that it will use the captive Python3 toolchain in Bazel (if one is configured), rather than system python. This is good because for hermetic builds, as we don't want to rely on system Python.

Details of the changes:
1. the dupe class checker python script is now called directly from Starlark instead of a genrule
2. the rule will now use python from the toolchain if it is configured
3. we now short circuit the invocation before invoking the python script if fail_on_duplicate_classes = False
4. the output file from the rule invocation will now contain the full description of the errors, if the invocation fails

Fixes issue #44 