### PR TITLE
pull through deps from the java_library

### DIFF
--- a/samples/helloworld/BUILD
+++ b/samples/helloworld/BUILD
@@ -43,7 +43,6 @@ springboot(
     name = "helloworld",
     boot_app_class = "com.sample.SampleMain",
     java_library = ":helloworld_lib",
-    deps = springboot_deps + lib_deps,
 
     # TO TEST THE DUPE CLASSES FEATURE:
     #   There is an intentionally duplicated class in lib1 and lib2. Do this:

--- a/tools/springboot/README.md
+++ b/tools/springboot/README.md
@@ -67,7 +67,6 @@ springboot(
     name = "helloworld",
     boot_app_class = "com.sample.SampleMain",
     java_library = ":helloworld_lib",
-    deps = springboot_deps,
 )
 ```
 
@@ -76,7 +75,6 @@ The required *springboot* rule attributes are as follows:
 -  name:    name of your application; the convention is to use the same name as the enclosing folder (i.e. the Bazel package name)
 -  boot_app_class:  the classname (java package+type) of the @SpringBootApplication class in your app
 -  java_library: the library containing your service code
--  deps:  list of jar file dependencies to add (these get packages as *BOOT-INF/lib* inside the executable jar)
 
 ### Convenience Import Bundles
 
@@ -210,6 +208,14 @@ springboot(
 The dupe class checking feature requires Python3.
 If you don't have Python3 available for your build, *fail_on_duplicate_classes* must be False.
 See [the Captive Python documentation](../python_interpreter) for more information on how to configure Python3.
+
+### Other Attributes
+
+The Spring Boot rule supports other attributes.
+
+- *visibility* standard
+- *tags* standard
+- *deps* will add additional jar files into the Spring Boot jar in addition to what is transitively used by the *java_library*
 
 ### Debugging the Rule Execution
 


### PR DESCRIPTION
Instead of reiterating the deps in the springboot rule, this PR allows the deps to be stated once in the java_library, and pulled through in the springboot rule. Fixes issue #31 .

**PREVIOUS:**
```
java_library(
    name = "helloworld_lib",
    srcs = glob(["src/main/java/**/*.java"]),
    resources = glob(["src/main/resources/**"]),
    deps = springboot_deps + lib_deps,
)

springboot(
    name = "helloworld",
    boot_app_class = "com.sample.SampleMain",
    java_library = ":helloworld_lib",
    deps = springboot_deps + lib_deps,
)
```

**NEW:**
```
java_library(
    name = "helloworld_lib",
    srcs = glob(["src/main/java/**/*.java"]),
    resources = glob(["src/main/resources/**"]),
    deps = springboot_deps + lib_deps,
)

springboot(
    name = "helloworld",
    boot_app_class = "com.sample.SampleMain",
    java_library = ":helloworld_lib",
    # NO DEPS NEED TO BE DECLARED HERE
)
```