### PR TITLE
support args for bazel run invocations

### DIFF
--- a/samples/helloworld/BUILD
+++ b/samples/helloworld/BUILD
@@ -51,4 +51,7 @@ springboot(
     #   Build should fail due to the duplicate class.
     fail_on_duplicate_classes = True,
     duplicate_class_allowlist = ":dupe_class_allowlist",
+
+    # Specify optional JVM args to use when the application is launched with 'bazel run'
+    jvm_flags = "-Dcustomprop=gold",
 )


### PR DESCRIPTION
This PR adds support for customization of launches using **bazel run**:

**JVM Args**

Defining JVM args for a spring boot application in the BUILD file   (Issue #36)
```
springboot(
    name = "helloworld",
    boot_app_class = "com.sample.SampleMain",
    java_library = ":helloworld_lib",
   jvm_flags = "-Dcustomprop=gold",
)
```

**Main Args**

Are now passed onto the Spring Boot application (Issue #8)
```
bazel run //samples/helloworld red green blue
```