### PR TITLE
implement support for classpath.idx file

### DIFF
--- a/samples/helloworld/BUILD
+++ b/samples/helloworld/BUILD
@@ -59,4 +59,8 @@ springboot(
 
     # data files can be made available in the working directory for when the app is launched with bazel run
     data = ["example_data.txt"],
+
+    # if you have conflicting classes in dependency jar files, you can define the order in which the jars are loaded
+    #  https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-war-index-files-classpath
+    classpath_index = "helloworld_classpath.idx",
 )

--- a/samples/helloworld/helloworld_classpath.idx
+++ b/samples/helloworld/helloworld_classpath.idx
@@ -1,0 +1,2 @@
+- "liblib1.jar"
+- "liblib2.jar"

--- a/samples/helloworld/src/main/java/com/sample/SampleMain.java
+++ b/samples/helloworld/src/main/java/com/sample/SampleMain.java
@@ -15,16 +15,18 @@ public class SampleMain {
 
   // both //samples/helloworld/libs/lib1 and //samples/helloworld/libs/lib2 have this class
   // this is only a problem if the springboot rule is configured to fail on dupes.
-  private IntentionalDupedClass dupedClass = new IntentionalDupedClass();
+  static private IntentionalDupedClass dupedClass = new IntentionalDupedClass();
 
   public static void main(String[] args) {
-    System.out.println("Launching the sample SpringBoot demo application...");
+    System.out.println("SampleMain: Launching the sample SpringBoot demo application...");
     StringBuffer sb = new StringBuffer();
     for (String arg : args) {
       sb.append(arg);
       sb.append(" ");
     }
-    System.out.println("  Command line args: "+sb.toString());
+    System.out.println("SampleMain:  Command line args: "+sb.toString());
+
+    System.out.println("\nSampleMain:  Intentional duped class version: "+dupedClass.hello());
 
     SpringApplication.run(SampleMain.class, args);
   }

--- a/tools/springboot/BUILD
+++ b/tools/springboot/BUILD
@@ -17,6 +17,7 @@ exports_files([
     "write_gitinfo_properties.sh",
     "write_manifest.sh",
     "dupe_class_jar_allowlist.txt",
+    "empty.txt",
 ])
 
 py_binary(


### PR DESCRIPTION
This implements the solution for #33 for classpath.idx files. This is a new feature in Spring Boot 2.3.

https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-war-index-files-classpath

This PR allows you to pass in a classpath.idx file, which will be positioned inside the Spring Boot executable jar file.

```
springboot(
    name = "helloworld",
    boot_app_class = "com.sample.SampleMain",
    java_library = ":helloworld_lib",

    # if you have conflicting classes in dependency jar files, you can define the order in which the jars are loaded
    #  https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-war-index-files-classpath
    classpath_index = "helloworld_classpath.idx",
)
```