### PR TITLE
document classpath index feature

### DIFF
--- a/samples/helloworld/BUILD
+++ b/samples/helloworld/BUILD
@@ -14,15 +14,6 @@ lib_deps = [
     "//samples/helloworld/libs/lib2",
 ]
 
-# service specific list of jars that we dont want to trigger errors for the
-# dupe class checker (these jars have known dupe classes)
-filegroup(
-    name = "dupe_class_allowlist",
-    srcs = glob([
-        "helloworld_dupeclass_allowlist.txt",
-    ]),
-)
-
 # create our deps list for Spring Boot
 springboot_deps = [
     "//tools/springboot/import_bundles:springboot_required_deps",
@@ -51,7 +42,7 @@ springboot(
     #   2. comment out lib1 or lib2 in helloworld_dupeclass_allowlist.txt
     #   Build should fail due to the duplicate class.
     fail_on_duplicate_classes = True,
-    duplicate_class_allowlist = ":dupe_class_allowlist",
+    duplicate_class_allowlist = "helloworld_dupeclass_allowlist.txt",
 
     # Specify optional JVM args to use when the application is launched with 'bazel run'
     jvm_flags = "-Dcustomprop=gold",

--- a/tools/springboot/README.md
+++ b/tools/springboot/README.md
@@ -116,6 +116,20 @@ The [//tools/springboot/import_bundles](import_bundles) package contains some ex
 There are bundles for the Spring Boot framework, as well as bundles for the various starters.
 The ones provided in this repository are just examples.
 
+### Excluding and Suppressing Unwanted Classes
+
+The Spring Boot rule will copy the transitive closure of all Java jar deps into the Spring Boot executable jar.
+This is normally what you want.
+
+But sometimes you have a transitive dependency that causes problems when included in your Spring Boot jar, but
+  you don't have the control to remove it from your dependency graph.
+This can cause problems such as:
+- multiple jars have the same class, but at different versions
+- an unwanted class carries a Spring annotation such that the class gets instantiated at startup
+
+The Spring Boot rule has a set of strategies and features for dealing with this situation, which unfortunately
+  is somewhat common:
+- [Excluding and suppressing unwanted classes](unwanted_classes.md) - excludes, dupe checking, classpath index
 
 ### Build Stamping of the Spring Boot jar
 
@@ -125,87 +139,6 @@ If you are interested in this feature, it is supported by this *springboot* rule
 However, to avoid breaking Bazel remote caching, we generally have this feature disabled for most builds.
 See the [//tools/buildstamp](../buildstamp) package for more details on how to enable and disable it.
 
-### Exclude list
-
-The Spring Boot rule will copy the transitive closure of all Java jar deps into the Spring Boot executable jar.
-This is normally what you want.
-But sometimes you have a transitive dependency that causes problems when included in your Spring Boot jar, but
-  you don't have the control to remove it from your dependency graph.
-
-An exclude list can be passed to the Spring Boot rule which will prevent that dependency from being copied into the jar.
-It is used like this:
-
-```
-springboot(
-    name = "helloworld",
-    boot_app_class = "com.sample.SampleMain",
-    java_library = ":helloworld_lib",
-    exclude = [
-      "@maven//:com_google_protobuf_protobuf_java",
-      "//protos/third-party/google/protobuf:any_java_proto",
-    ],
-)
-```
-
-### Duplicate Classes Detection
-
-Spring Boot jars normally aggregate a great number of dependency jars, many from outside the Bazel
-  build (external Maven-built jars).
-We have had cases where multiple jars brought in the same class, but at different versions.
-These problems are difficult to diagnose.
-
-There is a feature on the *springboot* rule that will fail the build if duplicate classes are detected.
-It is disabled by default, but can be enabled with an attribute:
-
-```
-springboot(
-    name = "helloworld",
-    boot_app_class = "com.sample.SampleMain",
-    java_library = ":helloworld_lib",
-    fail_on_duplicate_classes = True,
-)
-```
-
-It will scan all inner jars file, and fail the build if:
-- the same class (package + classname) is found in more than one inner jar, AND...
-- the MD5 hash of the classfile bytes differ
-
-But sometimes you have transitives that are out of your control that bring in duplicate classes.
-If you cannot use the *exclude* attribute as shown above, there is another solution.
-To ignore certain jars from the dupe checker, create a text file in the same directory
-  as the BUILD file.
-Add a jar filename on each line like this:
-
-```
-# write the filename of the jar file that should be excluded from dupe detection
-jakarta.annotation-api-1.3.5.jar
-spring-jcl-5.2.1.RELEASE.jar
-libfoo1.jar
-libfoo2.jar
-```
-
-and then follow this pattern in the BUILD file:
-
-```
-filegroup(
-    name = "dupe_class_allowlist",
-    srcs = glob([
-        "my_dupeclass_allowlist.txt",
-    ]),
-)
-
-springboot(
-    name = "helloworld",
-    boot_app_class = "com.sample.SampleMain",
-    java_library = ":helloworld_lib",
-    fail_on_duplicate_classes = True,
-    duplicate_class_allowlist = ":dupe_class_allowlist",
-)
-```
-
-The dupe class checking feature requires Python3.
-If you don't have Python3 available for your build, *fail_on_duplicate_classes* must be False.
-See [the Captive Python documentation](../python_interpreter) for more information on how to configure Python3.
 
 ### Customizing Bazel Run
 

--- a/tools/springboot/springboot.bzl
+++ b/tools/springboot/springboot.bzl
@@ -112,7 +112,7 @@ _dupeclasses_rule = rule(
         "dupeclasses_rule": attr.label(),
         "script": attr.label(),
         "springbootjar": attr.label(),
-        "allowlist": attr.label(),
+        "allowlist": attr.label(allow_files=True),
         "fail_on_duplicate_classes": attr.bool(),
         "out": attr.string(),
     },

--- a/tools/springboot/unwanted_classes.md
+++ b/tools/springboot/unwanted_classes.md
@@ -1,0 +1,109 @@
+## Excluding and Suppressing Unwanted Classes
+
+Spring Boot jars normally aggregate a great number of dependency jars, many from outside the Bazel
+  build (external Maven-built jars).
+The Spring Boot rule will copy the transitive closure of all Java jar deps into the Spring Boot executable jar.
+This is normally what you want.
+
+But sometimes you have a transitive dependency that causes problems when included in your Spring Boot jar, but
+  you don't have the control to remove it from your dependency graph.
+This can cause problems such as:
+- multiple jars have the same class, but at different versions
+- an unwanted class carries a Spring annotation such that the class gets instantiated at startup
+
+The Spring Boot rule has a set of strategies and features for dealing with this situation, which unfortunately
+  is somewhat common.
+
+
+### Duplicate Classes Detection
+
+We have had cases where multiple jars brought in the same class, but at different versions.
+These problems are difficult to diagnose.
+
+There is a feature on the *springboot* rule that will fail the build if duplicate classes are detected.
+It is disabled by default, but can be enabled with an attribute:
+
+```
+springboot(
+    name = "helloworld",
+    boot_app_class = "com.sample.SampleMain",
+    java_library = ":helloworld_lib",
+    fail_on_duplicate_classes = True,
+)
+```
+
+It will scan all inner jars file, and fail the build if:
+- the same class (package + classname) is found in more than one inner jar, AND...
+- the MD5 hash of the classfile bytes differ
+
+But sometimes you have transitives that are out of your control that bring in duplicate classes.
+If you cannot use the *exclude* attribute as shown below, there is another solution.
+To ignore certain jars from the dupe checker, create a text file in the same directory
+  as the BUILD file.
+Add a jar filename on each line like this:
+
+```
+# write the filename of the jar file that should be excluded from dupe detection
+jakarta.annotation-api-1.3.5.jar
+spring-jcl-5.2.1.RELEASE.jar
+libfoo1.jar
+libfoo2.jar
+```
+
+and then follow this pattern in the BUILD file:
+
+```
+springboot(
+    name = "helloworld",
+    boot_app_class = "com.sample.SampleMain",
+    java_library = ":helloworld_lib",
+    fail_on_duplicate_classes = True,
+    duplicate_class_allowlist = "my_dupeclass_allowlist.txt",
+)
+```
+
+The dupe class checking feature requires Python3.
+If you don't have Python3 available for your build, *fail_on_duplicate_classes* must be False.
+See [the Captive Python documentation](../python_interpreter) for more information on how to configure Python3.
+
+
+### Exclude List
+
+An exclude list can be passed to the Spring Boot rule which will prevent that dependency from being copied into the jar.
+It is used like this:
+
+```
+springboot(
+    name = "helloworld",
+    boot_app_class = "com.sample.SampleMain",
+    java_library = ":helloworld_lib",
+    exclude = [
+      "@maven//:com_google_protobuf_protobuf_java",
+      "//protos/third-party/google/protobuf:any_java_proto",
+    ],
+)
+```
+
+
+### Classpath Index
+
+Another approach for suppressing unwanted classes is to establish a particular classpath order with a *classpath index*.
+The classpath index is a [Spring Boot feature]() (starting with Spring Boot 2.3) that allows you to
+  instruct the Spring Boot loader to load one jar before another.
+This can be used to load the preferred classes first, which will occlude the unwanted classes loaded later.
+
+The feature is explained in the Spring Boot documentation:
+- [Spring Boot Classpath Index](https://docs.spring.io/spring-boot/docs/current/reference/html/appendix-executable-jar-format.html#executable-jar-war-index-files-classpath)
+
+The Spring Boot rule exposes the *classpath_index* attribute:
+
+```
+springboot(
+    name = "helloworld",
+    boot_app_class = "com.sample.SampleMain",
+    java_library = ":helloworld_lib",
+
+    # if you have conflicting classes in dependency jar files, you can define the order in which the jars are loaded-jar-war-index-files-classpath
+    classpath_index = "helloworld_classpath.idx",
+)
+```


### PR DESCRIPTION
Docs for issue #33, consolidated in a new doc unwanted.md with the exclude list, and dupe class checker.

Also introduced a minor simplification for the dupe class checker allowlist - the passed value can now be a file, which simplifies the usage.