### PR TITLE
remove two verbose log lines from springboot rule execution

### DIFF
--- a/samples/helloworld/remote_debug.sh
+++ b/samples/helloworld/remote_debug.sh
@@ -1,0 +1,3 @@
+# Remote attach debugging of the helloworld executable jar
+
+java -Xdebug -Xrunjdwp:transport=dt_socket,address=8000,server=y,suspend=y -jar ../../bazel-bin/samples/helloworld/helloworld.jar

--- a/tools/springboot/springboot_pkg.sh
+++ b/tools/springboot/springboot_pkg.sh
@@ -97,10 +97,10 @@ echo "  CLASSPATH_INDEX $CLASSPATH_INDEX (the location of the classpath index fi
 echo "  DEPLIBS         (list of upstream transitive dependencies, these will be incorporated into the jar file in BOOT-INF/lib )" >> $DEBUGFILE
 
 # compute path to jar utility
-pushd .
+pushd . > /dev/null
 cd $JAVABASE/bin
 JAR_COMMAND=$(pwd)/jar
-popd
+popd > /dev/null
 echo "Jar command:" >> $DEBUGFILE
 echo $JAR_COMMAND >> $DEBUGFILE
 


### PR DESCRIPTION
pushd and popd have been writing useless lines into the build log, finally got around to tracking it down and fixing it